### PR TITLE
Add variable highlighting

### DIFF
--- a/Syntaxes/PostCSS.tmLanguage
+++ b/Syntaxes/PostCSS.tmLanguage
@@ -344,6 +344,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#function-content-var</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#operator</string>
 				</dict>
 				<dict>
@@ -512,6 +516,13 @@
 			<key>name</key>
 			<string>string.quoted.double.css.sass</string>
 		</dict>
+		<key>function-content-var</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;=var\().+(?=\))</string>
+			<key>name</key>
+			<string>variable.parameter.sass</string>
+		</dict>
 		<key>interpolation</key>
 		<dict>
 			<key>begin</key>
@@ -677,7 +688,7 @@
 			<key>match</key>
 			<string>\$[\w-]+</string>
 			<key>name</key>
-			<string>variable.other.value</string>
+			<string>variable.parameter.sass</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
Addresses #1. I fiddled until I got this close to what I’m expecting.

![variable highlighting proposal](https://cloud.githubusercontent.com/assets/188426/10920783/117fdd74-8240-11e5-91c4-47b9a8b1e843.png)

Note that `var` is not highlighted to appear as a function, but the variable is highlighted to appear as a variable.
